### PR TITLE
Fix CIDR prefix validation

### DIFF
--- a/VLSM_Calculator.py
+++ b/VLSM_Calculator.py
@@ -14,7 +14,7 @@ class VLSMCalculator():
         if self._is_address_valid(ip_address) is False:
             return None, "Dirección IP Inválida.", None
         
-        if self.is_prefix_correct(prefix) is False:
+        if prefix != "" and self.is_prefix_correct(prefix) is False:
             return None, "CIDR Inválido.", None
         
         if self.is_host_number_correct(string_of_hosts) is False:
@@ -132,7 +132,10 @@ class VLSMCalculator():
         return True
     
     def is_prefix_correct(self, prefix):
-        if not prefix.isdigit() or int(prefix) < 0 or int(prefix) > 255:
+        if not prefix.isdigit():
+            return False
+        value = int(prefix)
+        if value < 0 or value > 32:
             return False
         return True
     


### PR DESCRIPTION
## Summary
- ensure optional CIDR input is validated only when provided
- restrict prefix validation to IPv4 range 0-32

## Testing
- `python -B -m py_compile VLSM_Calculator.py`
- `python - <<'PY'
from VLSM_Calculator import VLSMCalculator
calc = VLSMCalculator()
print('is_prefix_correct("33"):', calc.is_prefix_correct('33'))
print('is_prefix_correct("-1"):', calc.is_prefix_correct('-1'))
print('is_prefix_correct("24"):', calc.is_prefix_correct('24'))
print('calculate_vlsm allows empty prefix?')
subnets, msg, hosts = calc.calculate_vlsm('192.168.0.0','10,20','')
print('message:', msg)
PY`
- `python - <<'PY'
from VLSM_Calculator import VLSMCalculator
calc = VLSMCalculator()
print(calc.calculate_vlsm('192.168.0.0', '10,20', '33')[1])
PY`

------
https://chatgpt.com/codex/tasks/task_e_689793cb1f68832f9b8c471507d06d70