### PR TITLE
Limit prefix validation to /32 range

### DIFF
--- a/Network_Calculator.py
+++ b/Network_Calculator.py
@@ -67,7 +67,7 @@ class NetworkCalculator():
             if octet > 255 or octet < 0:
                 return "IP inválida"
         if self.cidr < 0 or self.cidr >32:
-            return "CIDR inválido"
+            return "CIDR inválido. Debe estar entre 0 y 32"
         if self.cidr < self.default_prefix:
             grouped_subnets = 1 / self.num_subnets
             self.num_subnets = f"Agrupa {int(grouped_subnets)} subredes de /{self.default_prefix}"

--- a/VLSM_Calculator.py
+++ b/VLSM_Calculator.py
@@ -15,7 +15,7 @@ class VLSMCalculator():
             return None, "Dirección IP Inválida.", None
         
         if self.is_prefix_correct(prefix) is False:
-            return None, "CIDR Inválido.", None
+            return None, "CIDR inválido. El prefijo debe estar entre 0 y 32.", None
         
         if self.is_host_number_correct(string_of_hosts) is False:
             return None, "Existen Hosts Inválidos.", None
@@ -132,7 +132,7 @@ class VLSMCalculator():
         return True
     
     def is_prefix_correct(self, prefix):
-        if not prefix.isdigit() or int(prefix) < 0 or int(prefix) > 255:
+        if not prefix.isdigit() or int(prefix) < 0 or int(prefix) > 32:
             return False
         return True
     


### PR DESCRIPTION
## Summary
- restrict VLSM prefix validation to 0-32 and clarify error message
- clarify CIDR validation error in network calculator

## Testing
- `python -m pytest`
- `python -m py_compile VLSM_Calculator.py Network_Calculator.py`


------
https://chatgpt.com/codex/tasks/task_e_6897979970c4832f95e9ed96033bc229